### PR TITLE
add product consumption statistics in purchase > inventory

### DIFF
--- a/product_average_consumption/__init__.py
+++ b/product_average_consumption/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/product_average_consumption/__openerp__.py
+++ b/product_average_consumption/__openerp__.py
@@ -1,0 +1,53 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Product - Average Consumption Module for Odoo
+#    Copyright (C) 2013-Today GRAP (http://www.grap.coop)
+#    @author Julien WESTE
+#    @author Sylvain LE GAL (https://twitter.com/legalsylvain)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': 'Product - Average Consumption',
+    'version': '9.0.1',
+    'category': 'Product',
+    'description': """
+Shows figures in the product form about the average consumption of products
+There are settings in Inventory/settings to define the calculation range and
+the display range.
+===========================================================================
+
+Copyright, Author and Licence :
+-------------------------------
+    * Copyright : 2013-Today, Groupement Régional Alimentaire de Proximité;
+    * Author :
+        * Julien WESTE;
+        * Sylvain LE GAL;
+        * Robin Keunen
+    * Licence : AGPL-3 (http://www.gnu.org/licenses/)
+    """,
+    'author': 'GRAP',
+    'website': 'http://www.grap.coop',
+    'license': 'AGPL-3',
+    'depends': [
+        'product',
+        'point_of_sale'
+    ],
+    'data': [
+        'views/product_template_view.xml',
+        # 'views/res_config_view.xml',
+    ],
+}

--- a/product_average_consumption/models/__init__.py
+++ b/product_average_consumption/models/__init__.py
@@ -1,0 +1,1 @@
+from . import product_template

--- a/product_average_consumption/models/product_template.py
+++ b/product_average_consumption/models/product_template.py
@@ -1,0 +1,40 @@
+# -*- encoding: utf-8 -*-
+from openerp import models, fields, api
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    consumption_calculation_method = fields.Selection(
+        selection=[('sales_history', 'Sales History')],
+        string="Consumption Calculation Method",
+        default='sales_history',
+    )
+    calculation_range = fields.Integer(
+        'Calculation range (days)',
+        default=14,
+    )
+
+    average_consumption = fields.Float(
+        string='Average consumption',
+        compute='_compute_average_daily_consumption',
+        digits=(100, 2),
+    )
+    total_consumption = fields.Integer(
+        string='Total consumption',
+        compute='_compute_total_consumption',
+    )
+    stock_coverage = fields.Float(
+        string='Stock coverage (days)',
+        compute='_compute_stock_coverage',
+        digits=(100, 2),
+    )
+
+    def _compute_average_daily_consumption(self):
+        return 6.8
+
+    def _compute_total_consumption(self):
+        return 67
+
+    def _compute_stock_coverage(self):
+        return 7.1

--- a/product_average_consumption/tests/__init__.py
+++ b/product_average_consumption/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_product_computations

--- a/product_average_consumption/tests/test_product_computations.py
+++ b/product_average_consumption/tests/test_product_computations.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+from openerp.tests.common import TransactionCase
+import datetime as dt
+
+_datetimes = map(
+    lambda d: d.strftime('%Y-%m-%d %H:%M:%S'),
+    (dt.datetime.now() - dt.timedelta(days=d) for d in range(0, 24, 2)))
+
+_quantities = [0.64, 6.45, 9.65, 1.76, 9.14, 3.99,
+               6.92, 2.25, 6.91, 1.44, 6.52, 1.44]
+
+
+class TestProductTemplate(TransactionCase):
+
+    def setUp(self, *args, **kwargs):
+        result = super(TestProductTemplate, self).setUp(*args, **kwargs)
+
+        # enrico_groups = [1, 2, 3, 4, 8, 9, 10, 11, 14, 18, 23,  # fixme
+        #                  24, 25, 27, 28, 32, 33, 34, 35, 36, 41,
+        #                  42, 43, 47, 48, 51, 52, 53, 54, 57, 59,
+        #                  60, 62, 63, 64, 65, 73, 75, 76, 77]
+        # # suspected_groups = [10, 35],
+        #
+        # user = self.env['res.users'].create({
+        #     'name': 'Test user product average consumption',
+        #     'login': 'testuserproductaverageconsumption',
+        #     'groups_id': [(6, 0, [enrico_groups])]
+        # })
+        # self.env = self.env(user=user)
+
+        test_product_template = (
+            self.env['product.template']
+                .create({'name': 'test product template',
+                         'calculation_range': 14,
+                         'consumption_calculation_method': 'sales_history',
+                         })
+        )
+
+        test_product = (
+            self.env['product.product']
+                .create({'name': 'test product',
+                         'product_tmpl_id': test_product_template.id
+                         })
+        )
+
+        for date, qty in zip(_datetimes, _quantities):
+            (self.env['pos.order.line']
+                 .create({'create_date': date,
+                          'qty': qty,
+                          'product_id': test_product.id
+                          })
+             )
+
+        self.test_product_template_id = test_product_template.id
+        return result
+
+    def test_create(self):
+        """Create a simple product template"""
+        Template = self.env['product.template']
+        product = Template.create({'name': 'Test product'})
+        self.assertEqual(product.name, 'Test product')
+
+    def test_compute_average_daily_consumption(self):
+        product_template = self.env['product.template'].browse(
+            self.test_product_template_id)
+        product_template.calculation_range = 14  # trigger compute
+        computed_value = product_template.average_consumption
+        expected_value = 4.08
+        self.assertEqual(computed_value, expected_value, 7)
+
+    def test_compute_total_consumption(self):
+        product_template = self.env['product.template'].browse(
+            self.test_product_template_id)
+        product_template.calculation_range = 14  # trigger compute
+        computed_value = product_template.total_consumption
+        expected_value = 57.11
+        self.assertEqual(computed_value, expected_value)

--- a/product_average_consumption/views/product_template_view.xml
+++ b/product_average_consumption/views/product_template_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<odoo>
+  <record id="beesdoo_product_form" model="ir.ui.view">
+      <field name="name">template.consumption.form</field>
+      <field name="model">product.template</field>
+      <field eval="7" name="priority"/>
+      <field name="inherit_id" ref="product.product_template_only_form_view"/>
+      <field name="arch" type="xml">
+      <group name="stock_property" position="after">
+        <group name="Consumption Figures">
+          <field name="consumption_calculation_method"/>
+          <field name="calculation_range" />
+          <field name="average_consumption"/>
+          <field name="total_consumption"/>
+        </group>
+      </group>
+    </field>
+  </record>
+</odoo>


### PR DESCRIPTION
- add fields to purchase > inventory view (form)
- compute total consumption by article
- compute average based on consumption

Please review and comment. It seems to be working on my side but I am concerned about performance as odoo would perform 2 requests per product. I don't know how to use the orm
efficiently since I need to fetch calculation range for each product.

Another option is to use the following raw sql query:

```sql
select
  template.id as product_template_id,
  sum(pol.qty) as total_consumption
from pos_order_line pol
  join pos_order po ON pol.order_id = po.id
  join product_product product ON pol.product_id = product.id
  join product_template template ON product.product_tmpl_id = template.id
  where po.state = 'done'
    and product.active
    and pol.create_date
        BETWEEN date_trunc('day', now()) - calculation_range * interval '1 days'
            and date_trunc('day', now())
    and template.id in (1489, 4790, 1962)
group by product_template_id
```
and map the results on the current recordset.