### PR TITLE
Add product code to article name in po lines

### DIFF
--- a/compute_purchase_order/models/computed_purchase_order.py
+++ b/compute_purchase_order/models/computed_purchase_order.py
@@ -170,8 +170,12 @@ class ComputedPurchaseOrder(models.Model):
 
         for cpo_line in self.order_line_ids:
             if cpo_line.purchase_quantity > 0:
+                if cpo_line.supplierinfo_id.product_code:
+                    pol_name = '[%s] %s' % (cpo_line.supplierinfo_id.product_code, cpo_line.name)
+                else:
+                    pol_name = cpo_line.name
                 pol_values = {
-                    'name': cpo_line.name,
+                    'name': pol_name,
                     'product_id': cpo_line.get_default_product_product().id,
                     'product_qty': cpo_line.purchase_quantity,
                     'price_unit': cpo_line.product_price,

--- a/compute_purchase_order/views/computed_purchase_order.xml
+++ b/compute_purchase_order/views/computed_purchase_order.xml
@@ -57,7 +57,6 @@
           <field name="order_line_ids" context="{'cpo_seller_id': supplier_id}">
             <tree string="Order Lines" editable='bottom'>
               <field name="product_template_id" domain="[('main_seller_id', '=', cpo_seller_id)]"/>
-              <field name="category_id" readonly='1'/>
               <field name="qty_available" readonly='1'/>
               <field name="uom_id" readonly='1'/>
               <field name="average_consumption" readonly='1'/>


### PR DESCRIPTION
Suppliers request the product code when receiving Purchase Orders.

CPO is useless without this code.